### PR TITLE
fix(limit-count): log timer callback redis errors

### DIFF
--- a/apisix/plugins/limit-count/limit-count-redis-cluster.lua
+++ b/apisix/plugins/limit-count/limit-count-redis-cluster.lua
@@ -52,7 +52,13 @@ local function log_phase_incoming_thread(premature, self, key, cost)
         return
     end
 
-    return util.redis_log_phase_incoming(self, self.red_cli, key, cost)
+    local res, err = util.redis_log_phase_incoming(self, self.red_cli, key, cost)
+    if err then
+        core.log.error("failed to deduct tokens in log phase: ", err)
+        return
+    end
+
+    return res
 end
 
 

--- a/apisix/plugins/limit-count/limit-count-redis.lua
+++ b/apisix/plugins/limit-count/limit-count-redis.lua
@@ -69,16 +69,21 @@ local function log_phase_incoming_thread(premature, self, key, cost)
     local conf = self.conf
     local red, err = redis.new(conf)
     if not red then
-        return red, err
+        core.log.error("failed to create redis in log phase: ", err)
+        return
     end
 
     local res, incoming_err = util.redis_log_phase_incoming(self, red, key, cost)
-    local ok, keepalive_err = release_connection(red, conf)
-    if not ok then
-        return nil, keepalive_err
+    local ok = release_connection(red, conf)
+    if incoming_err then
+        core.log.error("failed to deduct tokens in log phase: ", incoming_err)
     end
 
-    return res, incoming_err
+    if not ok then
+        return
+    end
+
+    return res
 end
 
 


### PR DESCRIPTION
## Summary
- log redis creation failures in limit-count log-phase timer callbacks
- log token deduction failures for both redis and redis-cluster backends
- keep the existing connection release logging behavior unchanged

## Testing
- luajit -b apisix/plugins/limit-count/limit-count-redis.lua
- luajit -b apisix/plugins/limit-count/limit-count-redis-cluster.lua
- attempted to run t/plugin/ai-rate-limiting.t in Lima, but the test environment could not detect nginx in PATH